### PR TITLE
Migrate GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,8 +10,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-node@v7.0.0
         with:
           node-version: 22
       - run: npm ci
@@ -23,8 +23,8 @@ jobs:
     # 設計: task_memory/20260428/resume_update/single_source_design.md §6.2
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-node@v7.0.0
         with:
           node-version: 22
       - run: npm ci
@@ -38,8 +38,8 @@ jobs:
     # 生成テンプレ起因の違反をすり抜けないよう独立ジョブで検査する。
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-node@v7.0.0
         with:
           node-version: 22
       - run: npm ci
@@ -50,7 +50,7 @@ jobs:
     # PR / push の差分に task_memory/ 配下が含まれていれば fail する。
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
       - name: Reject task_memory/ changes

--- a/.github/workflows/npmVersionUp.yaml
+++ b/.github/workflows/npmVersionUp.yaml
@@ -17,7 +17,10 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 22
       - name: cat package
         run: cat ./package.json
       - name: Git config

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,10 +20,10 @@ jobs:
       name: build pdf and release
       runs-on: ubuntu-latest
       steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7.0.0
         with:
           node-version: 22
       - run: npm ci

--- a/.github/workflows/reminder.yaml
+++ b/.github/workflows/reminder.yaml
@@ -8,12 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      contents: read
     steps:
+      - uses: actions/checkout@v7.0.1
       - name: Get date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
       - name: Create issue
-        uses: peter-evans/create-issue-from-file@v3
+        uses: peter-evans/create-issue-from-file@v6.0.0
         with:
           title: Remind resume update - ${{ steps.date.outputs.date }}
           content-filepath: .github/ISSUE_TEMPLATE/resume-remind.md

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -76,8 +76,8 @@
 
 `release.yaml` のジョブ `build` が以下のステップを順に実行します（`.github/workflows/release.yaml` 抜粋）。
 
-1. **`actions/checkout@v4`** — リポジトリと全タグをチェックアウト。
-2. **`actions/setup-node@v4` (Node.js 22)** — Node.js のセットアップ。
+1. **`actions/checkout@v7.0.1`** — リポジトリと全タグをチェックアウト。
+2. **`actions/setup-node@v7.0.0` (Node.js 22)** — Node.js のセットアップ。
 3. **`npm ci`** — ロックファイルどおりに依存をインストール。
 4. **`npm run build`** — `md-to-pdf` が `docs/README.md` を読み込み、`config/md-to-pdf.config.json` の設定に従って `dist/resume.pdf` を生成。
 5. **`mathieudutour/github-tag-action@v6.2`** — 直前のタグを起点に、`releaseSize` で指定したパートを 1 つ上げて新しい Git タグを作成（例: `v2.0.4` → `patch` で `v2.0.5`）。


### PR DESCRIPTION
## Summary
- update `actions/checkout` to `v7.0.1` and `actions/setup-node` to `v7.0.0`
- update the quarterly reminder action to `peter-evans/create-issue-from-file@v6.0.0`
- replace deprecated `set-output` syntax and add the checkout/permissions needed to read the issue template
- align the release guide with the current action versions

## Why
The post-merge `main` run for #56 succeeded but emitted Node 20 runtime deprecation warnings for every v4 action. These releases use the supported Node 24 action runtime.

## Verification
- all workflow YAML files parsed successfully
- `git diff --check`
- stale v3/v4 action and `set-output` references removed
- full GitHub Actions checks will run on this PR